### PR TITLE
Add Stripe billing and ATS generation limits

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -17,3 +17,10 @@ OPENAI_API_KEY="sk-..."
 
 # Optional: Use a different model
 # OPENAI_MODEL="gpt-4o"
+
+# Stripe Billing
+STRIPE_SECRET_KEY=""
+STRIPE_WEBHOOK_SECRET=""
+STRIPE_PRICE_ID=""
+# Public app URL for checkout redirects (e.g., https://app.example.com)
+NEXT_PUBLIC_APP_URL="http://localhost:3000"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -23,6 +23,7 @@
     "pdf-parse": "^2.4.5",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "stripe": "^14.14.0",
     "tailwind-merge": "^2.6.0",
     "zod": "^3.24.1"
   },

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -17,6 +17,8 @@ model User {
   email         String?   @unique
   emailVerified DateTime?
   image         String?
+  stripeCustomerId String? @unique
+  atsGenerationCount Int @default(0)
   createdAt     DateTime  @default(now())
   updatedAt     DateTime  @updatedAt
 
@@ -24,6 +26,7 @@ model User {
   sessions     Session[]
   profile      UserProfile?
   applications Application[]
+  subscription Subscription?
 
   @@map("users")
 }
@@ -179,6 +182,26 @@ model ResumeVersion {
   @@index([applicationId])
   @@index([baseResumeId])
   @@map("resume_versions")
+}
+
+// ============================================
+// Billing
+// ============================================
+
+model Subscription {
+  id                    String   @id @default(cuid())
+  userId                String   @unique
+  stripeCustomerId      String
+  stripeSubscriptionId  String   @unique
+  status                String
+  currentPeriodEnd      DateTime?
+  cancelAtPeriodEnd     Boolean  @default(false)
+  createdAt             DateTime @default(now())
+  updatedAt             DateTime @updatedAt
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@map("subscriptions")
 }
 
 // ============================================

--- a/apps/web/src/app/api/billing/checkout/route.ts
+++ b/apps/web/src/app/api/billing/checkout/route.ts
@@ -1,0 +1,82 @@
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import { stripe } from "@/lib/stripe";
+
+function resolveAppUrl() {
+  return (
+    process.env.NEXT_PUBLIC_APP_URL ||
+    process.env.NEXTAUTH_URL ||
+    "http://localhost:3000"
+  );
+}
+
+export async function POST() {
+  try {
+    const session = await auth();
+    if (!session?.user?.id) {
+      return NextResponse.json(
+        { success: false, error: "Unauthorized" },
+        { status: 401 }
+      );
+    }
+
+    const priceId = process.env.STRIPE_PRICE_ID;
+    if (!priceId) {
+      return NextResponse.json(
+        { success: false, error: "Stripe price is not configured" },
+        { status: 500 }
+      );
+    }
+
+    const user = await db.user.findUnique({
+      where: { id: session.user.id },
+    });
+
+    if (!user) {
+      return NextResponse.json(
+        { success: false, error: "User not found" },
+        { status: 404 }
+      );
+    }
+
+    let stripeCustomerId = user.stripeCustomerId;
+
+    if (!stripeCustomerId) {
+      const customer = await stripe.customers.create({
+        email: user.email || undefined,
+        name: user.name || undefined,
+        metadata: { userId: user.id },
+      });
+      stripeCustomerId = customer.id;
+      await db.user.update({
+        where: { id: user.id },
+        data: { stripeCustomerId },
+      });
+    }
+
+    const appUrl = resolveAppUrl();
+    const checkoutSession = await stripe.checkout.sessions.create({
+      mode: "subscription",
+      customer: stripeCustomerId,
+      line_items: [{ price: priceId, quantity: 1 }],
+      allow_promotion_codes: true,
+      success_url: `${appUrl}/applications?checkout=success`,
+      cancel_url: `${appUrl}/applications?checkout=cancel`,
+      metadata: { userId: user.id },
+    });
+
+    return NextResponse.json({
+      success: true,
+      data: { url: checkoutSession.url },
+    });
+  } catch (error) {
+    console.error("Failed to create checkout session:", error);
+    return NextResponse.json(
+      { success: false, error: "Failed to create checkout session" },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/src/app/api/billing/webhook/route.ts
+++ b/apps/web/src/app/api/billing/webhook/route.ts
@@ -1,0 +1,122 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+import { NextResponse } from "next/server";
+import { headers } from "next/headers";
+import type Stripe from "stripe";
+import { stripe } from "@/lib/stripe";
+import { db } from "@/lib/db";
+
+async function upsertSubscription(params: {
+  userId: string;
+  stripeCustomerId: string;
+  subscription: Stripe.Subscription;
+}) {
+  const { userId, stripeCustomerId, subscription } = params;
+  const currentPeriodEnd = subscription.current_period_end
+    ? new Date(subscription.current_period_end * 1000)
+    : null;
+
+  await db.subscription.upsert({
+    where: { userId },
+    update: {
+      stripeCustomerId,
+      stripeSubscriptionId: subscription.id,
+      status: subscription.status,
+      currentPeriodEnd,
+      cancelAtPeriodEnd: subscription.cancel_at_period_end ?? false,
+    },
+    create: {
+      userId,
+      stripeCustomerId,
+      stripeSubscriptionId: subscription.id,
+      status: subscription.status,
+      currentPeriodEnd,
+      cancelAtPeriodEnd: subscription.cancel_at_period_end ?? false,
+    },
+  });
+}
+
+export async function POST(request: Request) {
+  const signature = (await headers()).get("stripe-signature");
+  const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
+
+  if (!signature || !webhookSecret) {
+    return NextResponse.json(
+      { success: false, error: "Missing Stripe signature" },
+      { status: 400 }
+    );
+  }
+
+  const body = await request.text();
+
+  let event: Stripe.Event;
+  try {
+    event = stripe.webhooks.constructEvent(body, signature, webhookSecret);
+  } catch (error) {
+    console.error("Stripe webhook signature verification failed:", error);
+    return NextResponse.json(
+      { success: false, error: "Invalid signature" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    switch (event.type) {
+      case "checkout.session.completed": {
+        const session = event.data.object as Stripe.Checkout.Session;
+        if (session.mode !== "subscription") break;
+        if (!session.subscription || !session.customer) break;
+
+        const stripeCustomerId = String(session.customer);
+        const userId = session.metadata?.userId;
+        const user = userId
+          ? await db.user.findUnique({ where: { id: userId } })
+          : await db.user.findFirst({ where: { stripeCustomerId } });
+
+        if (!user) break;
+
+        const subscription = await stripe.subscriptions.retrieve(
+          String(session.subscription)
+        );
+
+        await db.user.update({
+          where: { id: user.id },
+          data: { stripeCustomerId },
+        });
+
+        await upsertSubscription({
+          userId: user.id,
+          stripeCustomerId,
+          subscription,
+        });
+        break;
+      }
+      case "customer.subscription.updated":
+      case "customer.subscription.deleted": {
+        const subscription = event.data.object as Stripe.Subscription;
+        const stripeCustomerId = String(subscription.customer);
+        const user = await db.user.findFirst({
+          where: { stripeCustomerId },
+        });
+        if (!user) break;
+        await upsertSubscription({
+          userId: user.id,
+          stripeCustomerId,
+          subscription,
+        });
+        break;
+      }
+      default:
+        break;
+    }
+
+    return NextResponse.json({ received: true });
+  } catch (error) {
+    console.error("Stripe webhook handling failed:", error);
+    return NextResponse.json(
+      { success: false, error: "Webhook handler failed" },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/src/lib/stripe.ts
+++ b/apps/web/src/lib/stripe.ts
@@ -1,0 +1,11 @@
+import Stripe from "stripe";
+
+const stripeSecretKey = process.env.STRIPE_SECRET_KEY;
+
+if (!stripeSecretKey) {
+  throw new Error("STRIPE_SECRET_KEY is not set");
+}
+
+export const stripe = new Stripe(stripeSecretKey, {
+  apiVersion: "2024-06-20",
+});


### PR DESCRIPTION
## Summary
- add Stripe checkout + webhook endpoints and stripe client
- gate ATS resume generation to 2 free lifetime uses
- store subscription + usage on the user and subscription tables
- surface upgrade CTA when limit reached
- document Stripe env vars

## Testing
- not run (requires Stripe env + DB migration)